### PR TITLE
Allow consistent newlines when under `items` limit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    env:
+      CI: true
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+      - run: yarn install --pure-lockfile
+      - run: yarn run lint
+      - run: yarn test

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ rules: {
 
 The rule accepts an option object with the following properties:
 
-- `items` [number] (default: `2`) - Specifies the maximum number of properties before the plugin requires breaking up the statement to multiple lines. If there are exactly this many or fewer properties, then the plugin will make sure the statement stays on one line unless it would violate the `maxLength` option. More properties than this number will always be split onto multiple lines.
+- `items` [number] (default: `2`) - Specifies the maximum number of properties before the plugin requires breaking up the statement to multiple lines. If there are exactly this many or fewer properties, then the plugin will make sure the statement stays on one line unless it would violate the `maxLength` option or `consistent` option is used. More properties than this number will always be split onto multiple lines.
 
-- `itemsWithRest` [number] (default: `1`) - Specifies the maximum number of properties **contain rest pattern** before the plugin requires breaking up the statement to multiple lines. If there are exactly this many or fewer properties, then the plugin will make sure the statement stays on one line unless it would violate the `maxLength` option. More properties than this number will always be split onto multiple lines.
+- `itemsWithRest` [number] (default: `1`) - Specifies the maximum number of properties **contain rest pattern** before the plugin requires breaking up the statement to multiple lines. If there are exactly this many or fewer properties, then the plugin will make sure the statement stays on one line unless it would violate the `maxLength` option or `consistent` option is used. More properties than this number will always be split onto multiple lines.
 
 - `maxLength` [number] (default: `Infinity`) - Specifies the maximum length for source code lines in your project, the plugin will split long destructuring lines even if they contains properties less than value in `items` or `itemsWithRest`
+
+- `consistent` [boolean] (default: false) - If there are less than the threshold items, allow new lines consistent with whether the curly braces are on their own lines or not.

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "jest --watch --onlyChanged",
+    "lint": "eslint ./src ./test",
     "test": "jest"
   },
   "files": [

--- a/test/newline.test.ts
+++ b/test/newline.test.ts
@@ -234,6 +234,27 @@ runner.run('option `maxLength` with others', newline, {
   ],
 });
 
+runner.run('option `consistent`', newline, {
+  valid: [
+    {
+      code: 'const { a, b } = foo;',
+      options: [{ consistent: true }],
+    },
+    {
+      code: 'const {\na,\nb\n} = foo;',
+      options: [{ consistent: true }],
+    },
+  ],
+  invalid: [
+    {
+      code: 'const {\na, b,\n} = foo;',
+      options: [{ consistent: true }],
+      errors: [{ messageId: CONSIST_NEWLINE }],
+      output: 'const {a,b} = foo;',
+    },
+  ],
+});
+
 runner.run('nested ones', newline, {
   valid: [
     {


### PR DESCRIPTION
Fixes #3 

This PR adds an option named `consistent` (similar to https://eslint.org/docs/latest/rules/object-curly-newline#consistent) that works when under the `items` limit to allow for consistent newlines or not. If the braces are not on the same line, then the properties must be on new lines.

This would allow both:

```js
// consistent new lines
const {
  readFile,
  writeFile,
} = require('fs');

// consistent no new lines
const { readFile, writeFile } = require('fs');
```

But not allow:

```js
// inconsistent new lines
const {
 readFile, writeFile,
} = require('fs');
```

I've also added a github action for running linting/tests too