### PR TITLE
Add prepack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
+    "build": "tsc --project tsconfig.build.json",
     "dev": "jest --watch --onlyChanged",
     "lint": "eslint ./src ./test",
+    "prepack": "tsc --project tsconfig.build.json",
     "test": "jest"
   },
   "files": [


### PR DESCRIPTION
This adds the `build` and `prepack` scripts to `package.json`.

The `build` script is just a convenience method.

The `prepack` script is automatically run by npm/yarn when packing/publishing a package and this will make sure packages are built just before being published. source: https://yarnpkg.com/advanced/lifecycle-scripts